### PR TITLE
get providers header fix

### DIFF
--- a/vericred_client/apis/providers_api.py
+++ b/vericred_client/apis/providers_api.py
@@ -159,7 +159,7 @@ Specialty name search.  So, searching "John Smith nose" would return
                  returns the request thread.
         """
 
-        all_params = ['body']
+        all_params = ['body', 'vericred_api_key']
         all_params.append('callback')
 
         params = locals()
@@ -179,6 +179,8 @@ Specialty name search.  So, searching "John Smith nose" would return
         query_params = {}
 
         header_params = {}
+        if 'vericred_api_key' in params:
+            header_params['Vericred-Api-Key'] = params['vericred_api_key']
 
         form_params = []
         local_var_files = {}

--- a/vericred_client/apis/providers_api.py
+++ b/vericred_client/apis/providers_api.py
@@ -129,18 +129,18 @@ class ProvidersApi(object):
         """
         Find Providers
         All `Provider` searches require a `zip_code`, which we use for weighting
-the search results to favor `Provider`s that are near the user.  For example,
-we would want "Dr. John Smith" who is 5 miles away to appear before
-"Dr. John Smith" who is 100 miles away.
+        the search results to favor `Provider`s that are near the user.  For example,
+        we would want "Dr. John Smith" who is 5 miles away to appear before
+        "Dr. John Smith" who is 100 miles away.
 
-The weighting also allows for non-exact matches.  In our prior example, we
-would want "Dr. Jon Smith" who is 2 miles away to appear before the exact
-match "Dr. John Smith" who is 100 miles away because it is more likely that
-the user just entered an incorrect name.
+        The weighting also allows for non-exact matches.  In our prior example, we
+        would want "Dr. Jon Smith" who is 2 miles away to appear before the exact
+        match "Dr. John Smith" who is 100 miles away because it is more likely that
+        the user just entered an incorrect name.
 
-The free text search also supports Specialty name search and "body part"
-Specialty name search.  So, searching "John Smith nose" would return
-"Dr. John Smith", the ENT Specialist before "Dr. John Smith" the Internist.
+        The free text search also supports Specialty name search and "body part"
+        Specialty name search.  So, searching "John Smith nose" would return
+        "Dr. John Smith", the ENT Specialist before "Dr. John Smith" the Internist.
 
 
         This method makes a synchronous HTTP request by default. To make an

--- a/vericred_client/models/provider.py
+++ b/vericred_client/models/provider.py
@@ -355,7 +355,7 @@ class Provider(object):
         :return: The npi of this Provider.
         :rtype: str
         """
-        return self.npi
+        return self._npi
 
     @npi.setter
     def npi(self, npi):

--- a/vericred_client/models/provider.py
+++ b/vericred_client/models/provider.py
@@ -63,7 +63,8 @@ class Provider(object):
             'suffix': 'str',
             'title': 'str',
             'type': 'str',
-            'zip_code': 'str'
+            'zip_code': 'str',
+            'npi': 'str'
         }
 
         self.attribute_map = {
@@ -93,7 +94,8 @@ class Provider(object):
             'suffix': 'suffix',
             'title': 'title',
             'type': 'type',
-            'zip_code': 'zip_code'
+            'zip_code': 'zip_code',
+            'npi': 'npi'
         }
 
         self._accepting_change_of_payor_patients = None
@@ -123,6 +125,7 @@ class Provider(object):
         self._title = None
         self._type = None
         self._zip_code = None
+        self._npi = None
 
     @property
     def accepting_change_of_payor_patients(self):
@@ -343,6 +346,26 @@ class Provider(object):
         :type: list[str]
         """
         self._hios_ids = hios_ids
+
+    @property
+    def npi(self):
+        """
+        Gets the npi of this Provider.
+
+        :return: The npi of this Provider.
+        :rtype: str
+        """
+        return self.npi
+
+    @npi.setter
+    def npi(self, npi):
+        """
+        Sets the npi of this Provider.
+
+        :param npi: The npi of this Provider.
+        :type: str
+        """
+        self._npi = npi
 
     @property
     def id(self):


### PR DESCRIPTION
get providers causes a bug since the header does not take in an api key. Just copied over code from the function above and it seems to fix the problem!
